### PR TITLE
Support nnsight >= 0.6

### DIFF
--- a/dictionary_learning/buffer.py
+++ b/dictionary_learning/buffer.py
@@ -3,9 +3,6 @@ from nnsight import LanguageModel
 import gc
 from tqdm import tqdm
 
-# nnsight >= 0.6 removed the scan/validate trace kwargs (tracing is always lazy).
-tracer_kwargs = {}
-
 
 class ActivationBuffer:
     """
@@ -119,7 +116,6 @@ class ActivationBuffer:
             with t.no_grad():
                 with self.model.trace(
                     self.text_batch(),
-                    **tracer_kwargs,
                     invoker_args={"truncation": True, "max_length": self.ctx_len},
                 ):
                     if self.io == "in":
@@ -257,7 +253,6 @@ class HeadActivationBuffer:
             with t.no_grad():
                 with self.model.trace(
                     self.text_batch(),
-                    **tracer_kwargs,
                     invoker_args={"truncation": True, "max_length": self.ctx_len},
                     remote=self.remote,
                 ):
@@ -449,7 +444,6 @@ class NNsightActivationBuffer:
 
             with t.no_grad(), self.model.trace(
                 self.token_batch(),
-                **tracer_kwargs,
                 invoker_args={"truncation": True, "max_length": self.ctx_len},
             ):
                 if self.io in ["in", "in_and_out"]:

--- a/dictionary_learning/buffer.py
+++ b/dictionary_learning/buffer.py
@@ -3,12 +3,8 @@ from nnsight import LanguageModel
 import gc
 from tqdm import tqdm
 
-from .config import DEBUG
-
-if DEBUG:
-    tracer_kwargs = {"scan": True, "validate": True}
-else:
-    tracer_kwargs = {"scan": False, "validate": False}
+# nnsight >= 0.6 removed the scan/validate trace kwargs (tracing is always lazy).
+tracer_kwargs = {}
 
 
 class ActivationBuffer:

--- a/dictionary_learning/cache.py
+++ b/dictionary_learning/cache.py
@@ -10,17 +10,14 @@ from tqdm.auto import tqdm
 from multiprocessing import Pool, Manager
 import time
 import json
-from .config import DEBUG
 from .utils import (
     dtype_to_str,
     str_to_dtype,
     torch_to_numpy_dtype,
 )
 
-if DEBUG:
-    tracer_kwargs = {"scan": True, "validate": True}
-else:
-    tracer_kwargs = {"scan": False, "validate": False}
+# nnsight >= 0.6 removed the scan/validate trace kwargs (tracing is always lazy).
+tracer_kwargs = {}
 
 import torch
 from typing import Tuple
@@ -640,7 +637,7 @@ class ActivationCache:
                 with model.trace(
                     tokens,
                     **tracer_kwargs,
-                ):
+                ) as tracer:
                     for i, submodule in enumerate(submodules):
                         local_activations = (
                             ActivationCache.get_activations(submodule, io)
@@ -650,7 +647,7 @@ class ActivationCache:
                         activation_cache[i].append(local_activations)
 
                     if last_submodule is not None:
-                        last_submodule.output.stop()
+                        tracer.stop()
 
                 for i in range(len(submodules)):
                     activation_cache[i][-1] = activation_cache[i][-1][

--- a/dictionary_learning/cache.py
+++ b/dictionary_learning/cache.py
@@ -16,9 +16,6 @@ from .utils import (
     torch_to_numpy_dtype,
 )
 
-# nnsight >= 0.6 removed the scan/validate trace kwargs (tracing is always lazy).
-tracer_kwargs = {}
-
 import torch
 from typing import Tuple
 
@@ -636,7 +633,6 @@ class ActivationCache:
             if overwrite or shape is None:
                 with model.trace(
                     tokens,
-                    **tracer_kwargs,
                 ) as tracer:
                     for i, submodule in enumerate(submodules):
                         local_activations = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 dependencies = [
     "torch",
-    "nnsight>=0.4,<0.6",
+    "nnsight>=0.6",
     "einops",
     "pytest",
     "datasets",


### PR DESCRIPTION
## What
Make `dictionary_learning` compatible with **nnsight >= 0.6** (currently capped at
`<0.6`).

## Why
nnsight 0.5.x runs `.save()` / tracing on **process-global** state (`Globals.stack`,
`Globals.saves`), mounting/unmounting the `.save`/`.stop` proxies on every trace
enter/exit guarded by a non-atomic counter. Under overlapping traces (e.g. multi-GPU
`device_map` hooks, or concurrent traces) this desyncs and surfaces as
`AttributeError: 'Tensor' object has no attribute 'save'` / `SystemError: unmount ...`.
nnsight 0.6 fixes this by redesigning the mechanism to **mount-once / never-unmount**.

Upgrading is blocked by two 0.5-only idioms in `ActivationCache.collect()`:
- `last_submodule.output.stop()` — the proxy `.stop()` early-stop was **removed in 0.6**
  → `AttributeError: 'Tensor' object has no attribute 'stop'`.
- the `scan=` / `validate=` trace kwargs — **obsolete in 0.6** (accepted as no-ops);
  dropped for cleanliness.

## Changes
- `cache.py`: capture the tracer (`with model.trace(...) as tracer:`) and call
  `tracer.stop()` instead of `last_submodule.output.stop()`.
- `cache.py`, `buffer.py`: drop the `scan`/`validate` trace kwargs (the `DEBUG`-gated
  dict → `{}`; nnsight 0.6 no longer has these kwargs).
- `pyproject.toml`: `nnsight>=0.4,<0.6` → `nnsight>=0.6`.

No public API changes; no behavior change to activation collection.

## Validation
Tested in isolated venvs that differ **only** in the nnsight/nnterp version (same torch,
transformers, model — so any difference is attributable to the upgrade):

- **`ActivationCache.collect()` is bit-identical** on nnsight 0.6.3 vs 0.5.15
  (`max_abs_diff = 0.0`, `np.array_equal == True`) — verified on a tiny model **and on a
  real 3B model** (layer 27, 3072-dim).
- **Without the patch**, `collect()` raises `AttributeError: 'Tensor' object has no
  attribute 'stop'` on 0.6.3 (the blocker, reproduced).
- **Test suite**: `pytest tests/` → 12 passed / 4 skipped (CUDA-gated), identical on
  nnsight 0.5.15, 0.6.3 and 0.7.0.
- **Whole-package check** (not just `collect()`): every nnsight idiom in
  `evaluation.py` / `buffer.py` / `interp.py` (`invoker_args`, `model.output.save()` /
  `model.input.save()`, `submodule.input[0].save()`, and the assignment-writes
  `submodule.output = (x_hat,)` / `submodule.output[0][:] = 0`) behaves **identically**
  across 0.5.15 / 0.6.3 / 0.7.0 (intervention-effective, same logit deltas). The change
  is behaviour-preserving for the whole package, not only the cache path.
- **Version range**: the pin is left open (`>=0.6`) — both **nnsight 0.6.3** and **0.7.0**
  (with nnterp 1.3.0) pass the full check above.